### PR TITLE
edit user form styled and other forms made more responsive

### DIFF
--- a/app/assets/stylesheets/pages/_signup.scss
+++ b/app/assets/stylesheets/pages/_signup.scss
@@ -1,5 +1,5 @@
 .sign-up-footer {
-  text-align: center;
+  text-align: center !important;
   margin: auto;
   padding-top: 20px;
 }

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,38 +1,44 @@
 <h2 class="text-center"><span class="red-dot">•</span> Edit <%= resource_name.to_s.humanize %> <span class="red-dot">•</span></h2>
-<div class="form-sign-up-container">
-  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-    <%= f.error_notification %>
+<div class="container mt-3">
+  <div class="row">
+    <div class="col-lg-3 col-md-2 col-sm-0">
+    </div>
+    <div class="form-sign-up-container col-lg-6 col-md-8 col-sm-12">
+      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= f.error_notification %>
 
-    <div class="form-inputs">
-      <%= f.input :email, required: true, autofocus: true %>
+        <div class="form-inputs">
+          <%= f.input :email, required: true, autofocus: true %>
 
-      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
+          <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+            <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
+          <% end %>
+
+          <%= f.input :password,
+                      hint: "leave it blank if you don't want to change it",
+                      required: false,
+                      input_html: { autocomplete: "new-password" } %>
+          <%= f.input :password_confirmation,
+                      required: false,
+                      input_html: { autocomplete: "new-password" } %>
+          <%= f.input :current_password,
+                      hint: "we need your current password to confirm your changes",
+                      required: true,
+                      input_html: { autocomplete: "current-password" } %>
+          <%= f.input :username, hint: "Do you want to change your username?"%>
+        </div>
+
+        <div class="form-actions">
+          <%= f.button :submit, "Update" %>
+        </div>
       <% end %>
-
-      <%= f.input :password,
-                  hint: "leave it blank if you don't want to change it",
-                  required: false,
-                  input_html: { autocomplete: "new-password" } %>
-      <%= f.input :password_confirmation,
-                  required: false,
-                  input_html: { autocomplete: "new-password" } %>
-      <%= f.input :current_password,
-                  hint: "we need your current password to confirm your changes",
-                  required: true,
-                  input_html: { autocomplete: "current-password" } %>
-      <%= f.input :username, hint: "Do you want to change your username?"%>
     </div>
-
-    <div class="form-actions">
-      <%= f.button :submit, "Update" %>
+    <div class="col-lg-3 col-md-2 col-sm-0">
     </div>
-  <% end %>
+  </div>
 </div>
 
 <div class="sign-up-footer">
-  <h3>Cancel my account</h3>
-
   <p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
   <%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,9 +2,9 @@
 <h2 class="text-center"><span class="red-dot">•</span> Sign up <span class="red-dot">•</span></h2>
 <div class="container mt-3">
   <div class="row">
-    <div class="col-3">
+    <div class="col-lg-3 col-md-2 col-sm-0">
     </div>
-    <div class="form-sign-up-container col-6">
+    <div class="form-sign-up-container col-lg-6 col-md-8 col-sm-12">
       <%= simple_form_for(resource, as: resource_name, class: "form-padding", url: registration_path(resource_name)) do |f| %>
         <%= f.error_notification %>
 
@@ -30,7 +30,7 @@
         </div>
       <% end %>
     </div>
-    <div class="col-3">
+    <div class="col-lg-3 col-md-2 col-sm-0">
     </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,9 +2,9 @@
 <h2 class="text-center"><span class="red-dot">•</span> Log in <span class="red-dot">•</span></h2>
 <div class="container mt-3">
   <div class="row">
-    <div class="col-3">
+    <div class="col-lg-3 col-md-2 col-sm-0">
     </div>
-    <div class="form-sign-up-container col-6">
+    <div class="form-sign-up-container col-lg-6 col-md-8 col-sm-12">
       <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <div class="form-inputs">
           <%= f.input :email,
@@ -22,7 +22,7 @@
         </div>
       <% end %>
     </div>
-    <div class="col-3">
+    <div class="col-lg-3 col-md-2 col-sm-0">
     </div>
   </div>
 </div>


### PR DESCRIPTION
I made the columns on the log in, sign up and edit profile forms responsive using col-lg-6 and so on, but these probably need to be replaced by a different system (not bootstrap columns) since right now the result looks very "jumpy"